### PR TITLE
Add detail pages and description generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,11 @@ to boost your ranking in the list beyond being added to the end.
 
 Site and code for evangeler.
 
+## Generating Affiliate Details
+
+Run `generate_details.py` to enrich `affiliates.json` with long form
+descriptions fetched from each website and generated via Claude 4. Set
+`CLAUDE_API_KEY` in your environment before running the script.
+
 
 Also see the YT video on [How to Make A Directory Business Like Evangeler.com](https://www.youtube.com/watch?v=OgZZumVhEH0&ab_channel=LeePenkman)

--- a/generate_details.py
+++ b/generate_details.py
@@ -1,0 +1,73 @@
+import json
+import os
+import re
+import requests
+from pathlib import Path
+
+API_URL = "https://api.anthropic.com/v1/messages"
+API_KEY = os.getenv("CLAUDE_API_KEY")
+
+
+def slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower())
+    return slug.strip("-")
+
+
+def fetch_website_content(url: str) -> str:
+    response = requests.get(url, timeout=10)
+    return response.text[:5000]
+
+
+def generate_detail(brand: str, website: str, description: str, content: str) -> str:
+    if not API_KEY:
+        raise RuntimeError("CLAUDE_API_KEY environment variable not set")
+
+    prompt = (
+        f"Write a concise 2-3 paragraph overview for the business {brand}. "
+        f"Use the following existing description: {description}. "
+        f"Here is some content from the website: {content}."
+    )
+
+    payload = {
+        "model": "claude-4",
+        "max_tokens": 300,
+        "messages": [
+            {"role": "user", "content": prompt}
+        ],
+    }
+    headers = {
+        "x-api-key": API_KEY,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+    resp = requests.post(API_URL, json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    # anthropic API returns messages content list
+    return data["content"][0]["text"]
+
+
+def main() -> None:
+    with open("affiliates.json") as f:
+        affiliates = json.load(f)
+
+    updated = False
+    for site in affiliates:
+        if site.get("detail"):
+            continue
+        try:
+            content = fetch_website_content(site["website"])
+            site["detail"] = generate_detail(site["brand"], site["website"], site["description"], content)
+            updated = True
+        except Exception as exc:
+            print(f"Failed generating detail for {site['brand']}: {exc}")
+
+    if updated:
+        Path("affiliates.json").write_text(json.dumps(affiliates, indent=4))
+        print("Updated affiliates.json with details")
+    else:
+        print("No updates were made")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/detail.jinja2
+++ b/templates/detail.jinja2
@@ -1,0 +1,24 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ site.brand }} - Details</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="/">Back to list</a>
+            <h1>{{ site.brand }}</h1>
+        </div>
+    </header>
+    <div class="container">
+        <img src="{{ static_url }}/evimg/{{ site.brand }}.webp" alt="{{ site.brand }}" width="144" height="144">
+        <p>{{ site.description }}</p>
+        {% if site.detail %}
+        <p>{{ site.detail }}</p>
+        {% endif %}
+        <p><a href="{{ site.website }}" target="_blank">Visit Website</a></p>
+    </div>
+</body>
+</html>

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -80,7 +80,7 @@
                                 >
                         </td>
                         <td>
-                            <a href="{{ site.website }}" target="_blank">{{ site.brand }}</a>
+                            <a href="/affiliate/{{ site.slug }}">{{ site.brand }}</a>
                         </td>
 
                         <td>


### PR DESCRIPTION
## Summary
- create helper to slugify brands and map affiliate pages
- display link to new detail page in the index
- add FastAPI route and template for affiliate detail pages
- provide `generate_details.py` script that calls Claude 4 to enrich `affiliates.json`
- document the details generator in `README`

## Testing
- `python -m py_compile main.py generate_details.py`