### PR TITLE
Add sitemap page and robots improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from fastapi import FastAPI, Form
+from fastapi.responses import Response
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.cors import CORSMiddleware
@@ -98,17 +99,30 @@ async def affiliate_detail(slug: str, request: Request):
 
 @app.get("/sitemap.xml")
 async def sitemap():
-    urls = [f"https://evangeler.com/affiliate/{d['slug']}" for d in affiliate_details]
-    xml_parts = ["<?xml version='1.0' encoding='UTF-8'?>", "<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>"]
+    urls = ["https://evangeler.com/", "https://evangeler.com/sitemap"] + [
+        f"https://evangeler.com/affiliate/{d['slug']}" for d in affiliate_details
+    ]
+    xml_parts = [
+        "<?xml version='1.0' encoding='UTF-8'?>",
+        "<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>",
+    ]
     for url in urls:
         xml_parts.append("  <url><loc>%s</loc></url>" % url)
     xml_parts.append("</urlset>")
-    return "\n".join(xml_parts)
+    return Response("\n".join(xml_parts), media_type="application/xml")
+
+
+@app.get("/sitemap")
+async def sitemap_html(request: Request):
+    return templates.TemplateResponse(
+        "templates/sitemap.jinja2",
+        {"request": request, "affiliates": affiliates, "static_url": static_url},
+    )
 
 
 @app.get("/robots.txt")
 async def robots():
-    return "User-agent: *\nAllow: /"
+    return "User-agent: *\nAllow: /\nSitemap: https://evangeler.com/sitemap.xml"
 
 
 @app.get("/search")

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -104,5 +104,8 @@
                 </table>
             </div>
         </div>
+        <footer>
+            <a href="/sitemap">Sitemap</a>
+        </footer>
 
 </html>

--- a/templates/sitemap.jinja2
+++ b/templates/sitemap.jinja2
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sitemap - Evangeler</title>
+    <link rel="canonical" href="https://evangeler.com/sitemap">
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <header>
+        <a href="/">Home</a>
+    </header>
+    <h1>Sitemap</h1>
+    <ul>
+        <li><a href="/">Home</a></li>
+        {% for site in affiliates %}
+        <li><a href="/affiliate/{{ site.slug }}">{{ site.brand }}</a></li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,6 +30,12 @@ def test_sitemap():
     assert affiliates[0]["slug"] in response.text
 
 
+def test_html_sitemap():
+    response = client.get("/sitemap")
+    assert response.status_code == 200
+    assert affiliates[0]["slug"] in response.text
+
+
 def test_search():
     response = client.get(f"/search?query={affiliates[0]['brand']}")
     assert response.status_code == 200
@@ -40,6 +46,7 @@ def test_robots():
     response = client.get("/robots.txt")
     assert response.status_code == 200
     assert "Allow: /" in response.text
+    assert "Sitemap: https://evangeler.com/sitemap.xml" in response.text
 
 
 def test_submit_form_get():


### PR DESCRIPTION
## Summary
- generate HTML sitemap listing all affiliate pages
- expose `/sitemap` endpoint and link in `robots.txt`
- include homepage and sitemap in `sitemap.xml`
- add canonical link and footer navigation
- serve sitemap XML with proper content type
- add tests for new functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68611d7b5d2c8333a564a0ce889336ba